### PR TITLE
refactor(telegrambot+common): move dedent+strip into get_bot_message

### DIFF
--- a/src/common/static.py
+++ b/src/common/static.py
@@ -1,5 +1,3 @@
-from textwrap import dedent
-
 class Static:
     """Тут просто статические константы для их дальнейшего использования"""
     def __init__(self):
@@ -80,33 +78,33 @@ class Static:
 
     ### Сообщения бота
     BOT_MESSAGES = {
-        "welcome_already_registered": dedent("""
+        "welcome_already_registered": """
             👋 С возвращением в OpenMAX!
             Ваш номер, если забыли: {phone}
-        """).strip(),
-        "welcome_new_user": dedent("""
+        """,
+        "welcome_new_user": """
             👋 Добро пожаловать на этот инстанс OpenMAX!
             У вас ещё нет аккаунта. Используйте /register для создания.
-        """).strip(),
-        "registration_success": dedent("""
+        """,
+        "registration_success": """
             ✅ Регистрация завершена!
             Ваш новый номер: {new_phone}
             Все коды для авторизации будут приходить сюда.
-        """).strip(),
-        "account_already_exists": dedent("""
+        """,
+        "account_already_exists": """
             ❌ У вас уже есть аккаунт.
-        """).strip(),
-        "id_not_whitelisted": dedent("""
+        """,
+        "id_not_whitelisted": """
             ❌ Ваш ID не находится в белом списке.
-        """).strip(),
-        "internal_error": dedent("""
+        """,
+        "internal_error": """
             ❌ Ошибка при регистрации аккаунта.
-        """).strip(),
-        "incoming_code": dedent("""
+        """,
+        "incoming_code": """
             Новая попытка входа в OpenMAX с вашим номером {phone}
             Код: {code}
             ❗️ Никому не сообщайте его, иначе можете потерять свой аккаунт!
-        """).strip()
+        """
     }
 
     ### Причины для жалоб

--- a/src/telegrambot/bot.py
+++ b/src/telegrambot/bot.py
@@ -3,6 +3,7 @@ import random
 import json
 import time
 from telebot.async_telebot import AsyncTeleBot
+from textwrap import dedent
 from common.static import Static
 from common.sql_queries import SQLQueries
 
@@ -109,7 +110,7 @@ class TelegramBot:
                         )
     
     def get_bot_message(self, msg_type):
-        return self.static.BOT_MESSAGES.get(msg_type)
+        return dedent(self.static.BOT_MESSAGES.get(msg_type)).strip()
 
     async def start(self):
         if self.enabled == True:


### PR DESCRIPTION
Этот небольшой PR выносит dedent+strip из локалей в get_bot_message. Уменьшается дублирование кода. Ну можно-же было сразу так сделать.